### PR TITLE
Sight check

### DIFF
--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.lishid</groupId>
   <artifactId>orebfuscator</artifactId>
-  <version>4.3.0-SNAPSHOT</version>
+  <version>4.3.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Orebfuscator4</name>
@@ -130,8 +130,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/Plugin/src/main/java/com/lishid/orebfuscator/config/ProximityHiderConfig.java
+++ b/Plugin/src/main/java/com/lishid/orebfuscator/config/ProximityHiderConfig.java
@@ -31,6 +31,7 @@ public class ProximityHiderConfig {
     private Integer y;
     private Boolean useSpecialBlock;
     private Boolean obfuscateAboveY;
+    private Boolean useFastGazeCheck;
     private Integer[] proximityHiderBlockIds;
     private BlockSetting[] proximityHiderBlockSettings;
     private int[] proximityHiderBlockMatrix;
@@ -43,6 +44,7 @@ public class ProximityHiderConfig {
         this.y = 255;
         this.useSpecialBlock = true;
         this.obfuscateAboveY = false;
+        this.useFastGazeCheck = false;
         this.proximityHiderBlockIds = defaultProximityHiderBlockIds;
     }
     
@@ -78,6 +80,10 @@ public class ProximityHiderConfig {
         
         if(this.proximityHiderBlockSettings == null && baseCfg.proximityHiderBlockSettings != null) {
         	this.proximityHiderBlockSettings = baseCfg.proximityHiderBlockSettings.clone();
+        }
+        
+        if (this.useFastGazeCheck == null) {
+        	this.useFastGazeCheck = baseCfg.useFastGazeCheck;
         }
         
         setProximityHiderBlockMatrix();
@@ -170,6 +176,14 @@ public class ProximityHiderConfig {
     			this.proximityHiderBlockMatrix[block.blockId] = block.obfuscateAboveY ? -block.y: block.y;
     		}
     	}
+    }
+    
+    public Boolean isUseFastGazeCheck() {
+    	return this.useFastGazeCheck;
+    }
+    
+    public void setUseFastGazeCheck(Boolean value) {
+    	this.useFastGazeCheck = value;
     }
 
     // Help methods

--- a/Plugin/src/main/java/com/lishid/orebfuscator/config/WorldReader.java
+++ b/Plugin/src/main/java/com/lishid/orebfuscator/config/WorldReader.java
@@ -228,6 +228,7 @@ public class WorldReader {
 	    Boolean useYLocationProximity = getBoolean(sectionPath + ".ObfuscateAboveY", cfg.isObfuscateAboveY(), withSave);
 	    Integer[] proximityHiderBlockIds = this.materialReader.getMaterialIdsByPath(sectionPath + ".ProximityHiderBlocks", cfg.getProximityHiderBlockIds(), withSave);
 	    ProximityHiderConfig.BlockSetting[] proximityHiderBlockSettings = readProximityHiderBlockSettings(sectionPath + ".ProximityHiderBlockSettings", cfg.getProximityHiderBlockSettings());
+	    Boolean useFastGazeCheck = getBoolean(sectionPath + ".UseFastGazeCheck", cfg.isUseFastGazeCheck(), withSave);
 	    
 	    cfg.setEnabled(enabled);
 	    cfg.setDistance(distance);
@@ -237,6 +238,7 @@ public class WorldReader {
 	    cfg.setObfuscateAboveY(useYLocationProximity); 
 	    cfg.setProximityHiderBlockIds(proximityHiderBlockIds);
 	    cfg.setProximityHiderBlockSettings(proximityHiderBlockSettings);
+	    cfg.setUseFastGazeCheck(useFastGazeCheck);
 	}
 	
 	private ProximityHiderConfig.BlockSetting[] readProximityHiderBlockSettings(

--- a/Plugin/src/main/java/com/lishid/orebfuscator/obfuscation/ProximityHider.java
+++ b/Plugin/src/main/java/com/lishid/orebfuscator/obfuscation/ProximityHider.java
@@ -145,6 +145,9 @@ public class ProximityHider extends Thread implements Runnable {
                     
                     ArrayList<BlockCoord> removedBlocks = new ArrayList<BlockCoord>();
                     Location playerLocation = p.getLocation();
+                    // 4.3.1 -- GAZE CHECK
+                    Location playerEyes = p.getEyeLocation();
+                    // 4.3.1 -- GAZE CHECK END
                     int minChunkX = (playerLocation.getBlockX() >> 4) - checkRadius;
                     int maxChunkX = minChunkX + (checkRadius << 1);
                     int minChunkZ = (playerLocation.getBlockZ() >> 4) - checkRadius;
@@ -167,19 +170,23 @@ public class ProximityHider extends Thread implements Runnable {
 		                        Location blockLocation = new Location(localPlayerInfo.getWorld(), b.x, b.y, b.z);
 		                        
 		                        if (proximityHider.isObfuscateAboveY() || playerLocation.distanceSquared(blockLocation) < distanceSquared) {
-		                            removedBlocks.add(b);
-		                            
-		                            BlockState blockState = Orebfuscator.nms.getBlockState(localPlayerInfo.getWorld(), b.x, b.y, b.z);
-		
-		                            if (blockState != null) {
-		                            	DeprecatedMethods.sendBlockChange(p, blockLocation, blockState);
-		                                final BlockCoord block = b;
-		                                final Player player = p;
-		                                Orebfuscator.instance.runTask(new Runnable() {
-		                                    public void run() {
-		                                    	Orebfuscator.nms.updateBlockTileEntity(block, player);
-		                                    }
-		                                });
+		                        	// 4.3.1 -- GAZE CHECK
+		                            if (!proximityHider.isUseFastGazeCheck() || doFastCheck(blockLocation, playerEyes, localPlayerInfo.getWorld())) {
+		                        	// 4.3.1 -- GAZE CHECK END
+			                            removedBlocks.add(b);
+			                            
+			                            BlockState blockState = Orebfuscator.nms.getBlockState(localPlayerInfo.getWorld(), b.x, b.y, b.z);
+			
+			                            if (blockState != null) {
+			                            	DeprecatedMethods.sendBlockChange(p, blockLocation, blockState);
+			                                final BlockCoord block = b;
+			                                final Player player = p;
+			                                Orebfuscator.instance.runTask(new Runnable() {
+			                                    public void run() {
+			                                    	Orebfuscator.nms.updateBlockTileEntity(block, player);
+			                                    }
+			                                });
+			                            }
 		                            }
 		                        }
 		                    }
@@ -198,6 +205,70 @@ public class ProximityHider extends Thread implements Runnable {
         }
 
         running = false;
+    }
+    
+    /**
+     * Basic idea here is to take some rays from the considered block to the player's eyes, and decide if
+     * any of those rays can reach the eyes unimpeded.
+     * 
+     * @param block the starting block
+     * @param eyes the destination eyes
+     * @param player the player world we are testing for
+     * @return true if unimpeded path, false otherwise
+     */
+    private boolean doFastCheck(Location block, Location eyes, World player) {
+    	double ex = eyes.getX();
+    	double ey = eyes.getY();
+    	double ez = eyes.getZ();
+    	double x = block.getBlockX();
+    	double y = block.getBlockY();
+    	double z = block.getBlockZ();
+    	return 	// midfaces
+    			fastAABBRayCheck(x, y, z, x    , y+0.5, z+0.5, ex, ey, ez, player) ||
+    			fastAABBRayCheck(x, y, z, x+0.5, y    , z+0.5, ex, ey, ez, player) ||
+    			fastAABBRayCheck(x, y, z, x+0.5, y+0.5, z    , ex, ey, ez, player) ||
+    			fastAABBRayCheck(x, y, z, x+0.5, y+1.0, z+0.5, ex, ey, ez, player) ||
+    			fastAABBRayCheck(x, y, z, x+0.5, y+0.5, z+1.0, ex, ey, ez, player) ||
+    			fastAABBRayCheck(x, y, z, x+1.0, y+0.5, z+0.5, ex, ey, ez, player) ||
+    			// corners
+    			fastAABBRayCheck(x, y, z, x  , y  , z  , ex, ey, ez, player) ||
+    			fastAABBRayCheck(x, y, z, x+1, y  , z  , ex, ey, ez, player) ||
+    			fastAABBRayCheck(x, y, z, x  , y+1, z  , ex, ey, ez, player) ||
+    			fastAABBRayCheck(x, y, z, x+1, y+1, z  , ex, ey, ez, player) ||
+    			fastAABBRayCheck(x, y, z, x  , y  , z+1, ex, ey, ez, player) ||
+    			fastAABBRayCheck(x, y, z, x+1, y  , z+1, ex, ey, ez, player) ||
+    			fastAABBRayCheck(x, y, z, x  , y+1, z+1, ex, ey, ez, player) ||
+    			fastAABBRayCheck(x, y, z, x+1, y+1, z+1, ex, ey, ez, player);
+    }
+    
+    private boolean fastAABBRayCheck(double bx, double by, double bz, double x, double y, double z, double ex, double ey, double ez, World world) {
+    	double fx = Math.abs(ex-x);
+    	double fy = Math.abs(ey-y);
+    	double fz = Math.abs(ez-z);
+    	double s = Math.max(fx, Math.max(fy, fz));
+    	if (s < 1) return true; // on top / inside
+    	
+    	double lx, ly, lz;
+    	
+    	fx = fx / s; // units of change along vector
+    	fy = fy / s;
+    	fz = fz / s;
+    	
+    	while (s > 0) {
+    		ex -= fx; // move along vector, we start _at_ the eye and move towards b
+    		ey -= fy;
+    		ez -= fz;
+    		lx = Math.floor(ex);
+    		ly = Math.floor(ey);
+    		lz = Math.floor(ez);
+    		if (lx == bx && ly == by && lz == bz) return true; // we've reached our starting block, don't test it.
+    		int between = Orebfuscator.nms.getBlockId(world, (int) lx, (int) ly, (int) lz);
+    		if (between > 0 && !Orebfuscator.config.isBlockTransparent(between)) { // -1 is null, 0 is air, above that? check with config.
+    			return false; // fail on first hit, this ray is "blocked"
+    		}
+    		s--; // we stop 
+    	}
+    	return true;
     }
 
     private static void restart() {

--- a/Plugin/src/main/java/com/lishid/orebfuscator/obfuscation/ProximityHider.java
+++ b/Plugin/src/main/java/com/lishid/orebfuscator/obfuscation/ProximityHider.java
@@ -242,6 +242,9 @@ public class ProximityHider extends Thread implements Runnable {
     }
     
     private boolean fastAABBRayCheck(double bx, double by, double bz, double x, double y, double z, double ex, double ey, double ez, World world) {
+    	boolean dx = ex > x;
+    	boolean dy = ey > y;
+    	boolean dz = ez > z;
     	double fx = Math.abs(ex-x);
     	double fy = Math.abs(ey-y);
     	double fz = Math.abs(ez-z);
@@ -255,9 +258,9 @@ public class ProximityHider extends Thread implements Runnable {
     	fz = fz / s;
     	
     	while (s > 0) {
-    		ex -= fx; // move along vector, we start _at_ the eye and move towards b
-    		ey -= fy;
-    		ez -= fz;
+    		ex = dx ? ex - fx : ex + fx; // move along vector, we start _at_ the eye and move towards b
+    		ey = dy ? ey - fy : ey + fy;
+    		ez = dz ? ez - fz : ez + fz;
     		lx = Math.floor(ex);
     		ly = Math.floor(ey);
     		lz = Math.floor(ez);

--- a/Plugin/src/main/java/com/lishid/orebfuscator/obfuscation/ProximityHider.java
+++ b/Plugin/src/main/java/com/lishid/orebfuscator/obfuscation/ProximityHider.java
@@ -242,13 +242,14 @@ public class ProximityHider extends Thread implements Runnable {
     }
     
     private boolean fastAABBRayCheck(double bx, double by, double bz, double x, double y, double z, double ex, double ey, double ez, World world) {
-    	boolean dx = ex > x;
-    	boolean dy = ey > y;
-    	boolean dz = ez > z;
-    	double fx = Math.abs(ex-x);
-    	double fy = Math.abs(ey-y);
-    	double fz = Math.abs(ez-z);
-    	double s = Math.max(fx, Math.max(fy, fz));
+        double fx = ex - x;
+        double fy = ey - y;
+        double fz = ez - z;
+    	double absFx = Math.abs(fx);
+    	double absFy = Math.abs(fy);
+    	double absFz = Math.abs(fz);
+    	double s = Math.max(absFx, Math.max(absFy, absFz));
+
     	if (s < 1) return true; // on top / inside
     	
     	double lx, ly, lz;
@@ -258,9 +259,9 @@ public class ProximityHider extends Thread implements Runnable {
     	fz = fz / s;
     	
     	while (s > 0) {
-    		ex = dx ? ex - fx : ex + fx; // move along vector, we start _at_ the eye and move towards b
-    		ey = dy ? ey - fy : ey + fy;
-    		ez = dz ? ez - fz : ez + fz;
+    		ex = ex - fx; // move along vector, we start _at_ the eye and move towards b
+    		ey = ey - fy;
+    		ez = ez - fz;
     		lx = Math.floor(ex);
     		ly = Math.floor(ey);
     		lz = Math.floor(ez);


### PR DESCRIPTION
**Feature Add** 

Gaze Check for ProximityHider (experimental).

**Description**

X-ray is an inherent problem in Minecraft due to the protocol design. Orebfuscator uses two large tools to combat and correct this flawed design. "Block obfuscation" which hides normal blocks which are fully covered, but does not well address "entities". Hence "Proximity Hider" -- which hides tile entities unless you are "proximate" or nearby. 

One big failure of this proximity hider, however, is it doesn't care if you can actually see the tile entity or not, using only distance to determine visibility or not. So, x-ray remains a _highly_ viable vector when "raiding" as it is difficult and unnatural for players to hide their chests and other valuables sufficiently to eliminate remote visibility without a full comprehension of the server's Proximity Hider config.

This feature makes a best-effort attempt to trade a little performance for a far superior protection. Using at most 14 "rays", it tests to see if the player's "eye location" has an unobscured line of sight to the tile entity in question. It uses fast AABB type "raytracing" math so that tile entities that are fully obscured (buried underground _completely_ -- all 26 "connected" sides)  will remain obscured even if the player is very proximate. 

This should allow fully achieving the promise of Proximity hider, where x-ray users cannot discover without normal effort the location of buried chests and other containers simply by getting nearby -- they now need a clear line of sight.

**Configuration changes**

Add the `UseFastGazeCheck: true` directive to your `ProximityHider` configuration sections in the worlds you want to activate it on.

Otherwise, it leverages the transparent block settings you've already defined, so no other configuration is necessary.

**Known Issues**

If a tile entity is only "capped" -- e.g. buried on all sides but there is just a single block on top of it -- due to the specifics of the ray traversal computations, these tile entities are still vulnerable to exposure. Simply ensure that all 26 "surrounding" blocks are fully non-transparent to address this. E.g. fully burying a chest underground by at least one full block should fully protect it.

Performance is a concern. This adds up to 14 "ray traversals" per person per proximity hid item, updated at your proximity hider normal update frequency on player full-block movement. We would love feedback on performance and impact.
